### PR TITLE
Migrate cn() to cnfast

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,11 +18,10 @@
   "dependencies": {
     "@base-ui/react": "catalog:",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
+    "cnfast": "^0.0.8",
     "lucide-react": "^1.16.0",
     "next-themes": "^0.4.6",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
     "vaul": "^1.1.2"
   },

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,10 +1,6 @@
 import * as React from "react";
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from "cnfast";
 
 export function useMediaQuery(query = "(min-width: 640px)") {
   const [value, setValue] = React.useState(false);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,9 +297,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cnfast:
+        specifier: ^0.0.8
+        version: 0.0.8
       lucide-react:
         specifier: ^1.16.0
         version: 1.16.0(react@19.2.6)
@@ -312,9 +312,6 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      tailwind-merge:
-        specifier: ^3.6.0
-        version: 3.6.0
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -323,7 +320,7 @@ importers:
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@kyh/tsconfig':
         specifier: 'catalog:'
@@ -2649,6 +2646,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cnfast@0.0.8:
+    resolution: {integrity: sha512-EjXKMfGfdwtV4AcNSQ6AwQaVzpC1B7IxeiwA3FlhTXz+YFlMKVi4c1JX9tgD2QOlahQXjB8KUXrBaYG+3v871Q==}
+    hasBin: true
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -6516,6 +6517,8 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
+
+  cnfast@0.0.8: {}
 
   code-block-writer@13.0.3: {}
 


### PR DESCRIPTION
## Summary

Migrates the `cn()` class-name helper in `@repo/ui` to use [cnfast](https://github.com/aidenybai/cnfast), a drop-in replacement for `clsx` + `tailwind-merge`. cnfast produces byte-identical output while running ~3.8x faster on average (up to 7x on component-heavy code).

## Changes

- `packages/ui/src/lib/utils.ts` — replace the hand-rolled `cn()` (`twMerge(clsx(inputs))`) with a re-export of `cn` from `cnfast`.
- `packages/ui/package.json` — drop the `clsx` and `tailwind-merge` direct dependencies, add `cnfast`.
- `pnpm-lock.yaml` — regenerated.

All `cn` consumers import via `@repo/ui/lib/utils`, so no call sites needed changes. The public `cn` signature is preserved.

## Verification

- `pnpm typecheck` — all 7 tasks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VksJa7nCQroPWRgAe6NATe)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cc2e4f056195f15f4588776a072cb77811ad2292. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the `cn()` helper in `@repo/ui` to `cnfast` for faster class merging. Output and API are unchanged, so no call sites were updated.

- **Refactors**
  - Re-export `cn` from `cnfast` in `packages/ui/src/lib/utils.ts`.
  - Keeps the public `cn` signature and byte-identical output.

- **Dependencies**
  - Replace `clsx` and `tailwind-merge` with `cnfast` in `@repo/ui/package.json`.
  - Regenerated `pnpm-lock.yaml`.

<sup>Written for commit cc2e4f056195f15f4588776a072cb77811ad2292. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/yours-sincerely/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

