### PR TITLE
fix(web): restore card drag by loading motion's domMax features

### DIFF
--- a/apps/web/src/components/providers/motion-provider.tsx
+++ b/apps/web/src/components/providers/motion-provider.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { domAnimation, LazyMotion, MotionConfig } from "motion/react";
+import { domMax, LazyMotion, MotionConfig } from "motion/react";
 
+// domMax, not domAnimation: the card stack's `drag` gesture is only included in
+// domMax, and LazyMotion drops it silently — cards render fine but won't drag.
 export const MotionProvider = ({ children }: { children: React.ReactNode }) => (
   <MotionConfig reducedMotion="user">
-    <LazyMotion features={domAnimation} strict>
+    <LazyMotion features={domMax} strict>
       {children}
     </LazyMotion>
   </MotionConfig>


### PR DESCRIPTION
## Description

Card drag stopped working on mobile (and everywhere else). The regression came from d1da092 ("perf(web): lazy-load motion features"), which switched `MotionProvider` to `LazyMotion` with the `domAnimation` feature bundle. `domAnimation` does **not** include drag/pan gesture support — that lives only in `domMax` — so the card stack's `drag="x"` was silently dropped: cards rendered and animated fine but no longer followed the finger, and the stack never advanced on swipe. Mobile is where this shows first because dragging is the primary way to advance the stack there (and the legacy Capacitor app runs this web bundle live in a WebView).

The fix swaps `domAnimation` for `domMax` in `apps/web/src/components/providers/motion-provider.tsx`, keeping the `LazyMotion`/`m` lazy-loading setup intact, with a comment explaining why `domMax` is required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `pnpm verify` (typecheck · lint · format · test) — passes.
- [x] Real-browser touch-drag test: ran the web app against a local Postgres with seeded posts, opened it in headless Chromium with a mobile viewport (390×844, touch enabled, `postView=stack` cookie), and dispatched a CDP touch drag across the top card.
  - **With the fix (`domMax`):** the top card's transform showed `translateX` tracking the finger mid-gesture (150px at midpoint) and the stack advanced to the next letter on release.
  - **Control on the unfixed code (`domAnimation`):** `translateX` stayed at 0 for the whole gesture and the top card never changed — reproducing the reported bug and confirming the test catches it.

**Test Configuration**:

- Headless Chromium via `playwright-core` with CDP `Input.dispatchTouchEvent`, mobile viewport + touch, Next.js dev server, local Postgres 16.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcAKycDkvSW41Kw8yrnSm6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcAKycDkvSW41Kw8yrnSm6)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore card drag/swipe on mobile and desktop by switching `LazyMotion` to use `domMax` features in the web `MotionProvider`. `domAnimation` omits drag/pan, which broke the stack’s `drag="x"`; `domMax` keeps lazy-loading while re-enabling gestures so cards follow the finger and advance on release.

<sup>Written for commit 06438e6e62692da56e2f62b1d43918b7d6c5db7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/yours-sincerely/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

