### PR TITLE
Order tasks by topo, not by upstream builds

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
       "dependsOn": ["^topo"]
     },
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^topo"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "dev": {
@@ -15,11 +15,11 @@
       "persistent": false
     },
     "typecheck": {
-      "dependsOn": ["^topo", "^build"],
+      "dependsOn": ["^topo"],
       "outputs": [".cache/tsbuildinfo.json"]
     },
     "test": {
-      "dependsOn": ["^topo", "^build"],
+      "dependsOn": ["^topo"],
       "outputs": []
     },
     "clean": {


### PR DESCRIPTION
`build`, `typecheck` and `test` all declared `^build`, making them wait on upstream builds that emit nothing.

`@repo/web` is the only package with a `build` script, and nothing depends on `@repo/web` — every workspace dependency (`@repo/api`, `@repo/contracts`, `@repo/db`, `@repo/ui`) is buildless. So all three edges resolved to nothing; `^topo` states the topological ordering without pretending upstream artifacts exist.

`test` carried the identical dead edge as its siblings, so it is fixed here too rather than left behind in the same file.

`outputs` declares `.next/**` and `.cache/tsbuildinfo.json`, both genuinely emitted — no dead `dist/**` to drop.

`pnpm verify` (typecheck · lint · format · test) and `pnpm build` both pass; the turbo graph still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes `turbo.json` so `build`, `typecheck`, and `test` tasks order by topo instead of waiting on upstream `build` tasks. Only `@repo/web` has a `build` script and nothing depends on it, so the old `^build` edges were dead; `^topo` expresses the ordering without pretending upstream artifacts exist.

<sup>Written for commit bcca71d9205ff7022c5c2da753623e615690fd58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/yours-sincerely/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

