### PR TITLE
Build in the verify gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "turbo run test",
     "typecheck": "turbo run typecheck",
     "format": "oxfmt --check",
-    "verify": "pnpm typecheck && pnpm lint && pnpm format && pnpm test",
+    "verify": "pnpm typecheck && pnpm lint && pnpm format && pnpm test && pnpm build",
     "lint:fix": "oxlint --fix",
     "format:fix": "oxfmt --write",
     "release:mobile:check": "dotenv -e .env -- node scripts/validate-mobile-release-env.mjs",


### PR DESCRIPTION
This repo's CI runs a single step, `pnpm verify`, and `verify` was typecheck, lint, format and test with no build. Nothing in CI ever built the repo, so a build break only showed up at the Vercel deploy.

Sibling repos already close this: uicapsule and idlebiz include `build` in `verify`, and init keeps a separate `Build` step in its workflow. This matches the first shape.

It matters more now that `typescript: { ignoreBuildErrors: true }` is gone repo-wide, since the build carries a real typecheck of the app's own files.

Verified: `pnpm verify` green end to end, including the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `build` to the `pnpm verify` script so CI catches build breaks before Vercel does. Previously `verify` never built the repo, and with `ignoreBuildErrors` removed, the build now carries a real typecheck of the app's own files.

<sup>Written for commit fb8ae333fbfe9a12888bfc182c8507d15b452cbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/yours-sincerely/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

