### PR TITLE
ci: split the verify step, fix the red build gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,19 @@
 name: CI
 
 on:
-  pull_request:
   push:
     branches: [main]
+  pull_request:
 
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  check:
+  ci:
     runs-on: ubuntu-latest
+    env:
+      TURBO_TELEMETRY_DISABLED: 1
     steps:
       - uses: actions/checkout@v6
 
@@ -20,6 +22,17 @@ jobs:
           runtime: node@24
           cache: true
 
-      # Same command developers and agents run locally, so the gate cannot drift.
-      - name: Verify
-        run: pnpm verify
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Format
+        run: pnpm format
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TURBO_TELEMETRY_DISABLED: 1
+      # `next build` runs as NODE_ENV=production, where the session signer fails
+      # closed rather than fall back to the dev constant. Throwaway: CI never
+      # signs a cookie anyone holds.
+      COOKIE_SECRET: yours-sincerely-ci-only-cookie-secret-not-a-real-signer
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Brings `.github/workflows/ci.yml` to the shape of the house reference (`init/.github/workflows/ci.yml`), and fixes the build gate, which has been red on `main` since #104.

## What changed

- **Steps**: one `Verify` step running `pnpm verify` → five named steps (Typecheck, Lint, Format, Test, Build). A failure is now readable from the checks list instead of buried in a single log.
- **Concurrency**: `cancel-in-progress: true` → `${{ github.event_name == 'pull_request' }}`, so a push to main is never cancelled by the next one. Group is now the reference's `${{ github.workflow }}-${{ github.ref }}`.
- **Env**: added `TURBO_TELEMETRY_DISABLED: 1`, and a throwaway `COOKIE_SECRET` — see below.
- Job renamed `check` → `ci` to match the reference. No branch protection rules or rulesets exist on this repo, so no required check breaks.

## The red build

#104 added `pnpm build` to `verify`, and CI has failed on `main` every run since:

```
Error: COOKIE_SECRET must be set (only NODE_ENV=development|test may use the dev fallback)
    at packages/api/src/auth/session-core.ts:51
```

`next build` runs as `NODE_ENV=production`, and `resolveCookieSecret` deliberately fails closed there rather than fall back to the public dev constant. The runner has no `.env`, so there is nothing to read. Fixed with a job-level throwaway secret — CI never signs a cookie anybody holds. Nothing else was needed; every route is dynamic, so page-data collection touches no database.

Confirmed by reproducing the runner locally: `next build` through `dotenv -e /dev/null` with only `COOKIE_SECRET` in the environment builds all 18 routes clean.

## Why the steps run the commands, not `pnpm verify`

This repo's `verify` is `typecheck && lint && format && test && build`. Calling `pnpm verify` from each of five steps would run the whole chain five times, build included. The steps run the underlying commands directly — same coverage, same order, once each.

## Verified locally

`pnpm typecheck` → `lint` → `format` → `test` → `build`, in workflow order. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)