### PR TITLE
Guard the ignorePatterns spread in oxlint config

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -9,7 +9,7 @@ const nextPackages = ["apps/web/**", "packages/api/**"];
 export default defineConfig({
   extends: [core, react, antiSlop],
   ignorePatterns: [
-    ...core.ignorePatterns,
+    ...(core.ignorePatterns ?? []),
     "dist-electron",
     ".expo",
     ".wxt",


### PR DESCRIPTION
`ultracite` types `OxlintConfig.ignorePatterns` as `string[] | undefined`, so spreading it bare is unsound:

```
oxlint.config.ts: error TS2488: Type 'string[] | undefined' must have a '[Symbol.iterator]()' method that returns an iterator.
```

Latent here rather than live, because `oxlint.config.ts` is not part of any tsconfig program (there is no root tsconfig, and no package program reaches it). The sibling eve repos do include it and already carry this guard — one of them hit the error on a fresh CI checkout.

At runtime `core.ignorePatterns` is a 53-item array, so `?? []` never fires: behavior is identical, and the file stays sound if it's ever added to a program.

Verified: `oxlint` clean (0 errors, 0 warnings), `oxfmt --check` clean, `turbo run typecheck --force` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards the spread of `core.ignorePatterns` in `oxlint.config.ts` so the file type-checks when included in a tsconfig program. The bare spread violated the `string[] | undefined` type from `ultracite`; the `?? []` fallback never fires at runtime because the array is always defined, so behavior is identical.

<sup>Written for commit 88997bf4fff591bcfce127f8d4375da2679bc3eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/yours-sincerely/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

